### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 Django KB
 =============================
 
-.. image:: https://pypip.in/version/django-kb/badge.svg
+.. image:: https://img.shields.io/pypi/v/django-kb.svg
     :target: https://pypi.python.org/pypi/django-kb/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/django-kb/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/django-kb.svg
     :target: https://pypi.python.org/pypi/django-kb/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/format/django-kb/badge.svg
+.. image:: https://img.shields.io/pypi/format/django-kb.svg
     :target: https://pypi.python.org/pypi/django-kb/
     :alt: Download format
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-kb))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-kb`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.